### PR TITLE
Fixed error for obsidian version v1.7.4

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,78 +1,103 @@
 const { Plugin } = require('obsidian');
 
-
+// Utility function to delay execution
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
 module.exports = class CollapseSubfoldersPlugin extends Plugin {
     async onload() {
-        console.log('Loading Collapse Subfolders Plugin');
-        await this.setupObserverWithRetries();
+        console.log('Loading Auto Folder Collapse Plugin');
+        this.registerEvent(this.app.workspace.on('layout-ready', () => {
+            this.setupObserverWithRetries();
+        }));
     }
 
     onunload() {
-        console.log('Unloading Collapse Subfolders Plugin');
         if (this.observer) {
             this.observer.disconnect();
         }
     }
 
-    async setupObserverWithRetries(retries = 3, delayMs = 1000) {
+    async setupObserverWithRetries(retries = 5, delayMs = 1000) {
         for (let i = 0; i < retries; i++) {
-            const fileExplorer = document.querySelector('.workspace-leaf-content');
+            const fileExplorer = this.getFileExplorerElement();
             if (fileExplorer) {
-                const observer = new MutationObserver((mutations) => {
-                    mutations.forEach((mutation) => {
-                        if (mutation.attributeName === 'class') {
-                            const target = mutation.target;
-                            if (target.classList.contains('is-collapsed')) {
-                                this.handleFolderCollapse(target);
-                            }
-                        }
-                    });
-                });
-
-                observer.observe(fileExplorer, {
-                    attributes: true,
-                    subtree: true,
-                    attributeFilter: ['class'],
-                });
-
-                this.observer = observer;
+                this.setupMutationObserver(fileExplorer);
                 return;
             } else {
-                console.log(`File explorer not found, retrying in ${delayMs}ms...`);
                 await sleep(delayMs);
             }
         }
-        console.error('Failed to set up observer after multiple retries');
     }
 
-    handleFolderCollapse(folder) {
-        const subfolders = folder.querySelectorAll('.nav-folder-children .nav-folder');
-        const collapsePromises = Array.from(subfolders).map(subfolder => this.collapseSubfolder(subfolder));
+    getFileExplorerElement() {
+        const selectors = [
+            '.nav-files-container.node-insert-event',
+            '.file-explorer-view',
+            '.workspace-leaf-content[data-type="file-explorer"]'
+        ];
 
-        Promise.all(collapsePromises).then(() => {
+        for (const selector of selectors) {
+            const element = document.querySelector(selector);
+            if (element) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    setupMutationObserver(fileExplorer) {
+        const observer = new MutationObserver((mutations) => {
+            for (const mutation of mutations) {
+                if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                    const target = mutation.target;
+                    if (target.classList.contains('is-collapsed')) {
+                        this.handleFolderCollapse(target);
+                    }
+                }
+            }
         });
+
+        observer.observe(fileExplorer, {
+            attributes: true,
+            subtree: true,
+            attributeFilter: ['class'],
+        });
+
+        this.observer = observer;
+    }
+
+    async handleFolderCollapse(folder) {
+        const subfoldersContainer = folder.querySelector('.nav-folder-children') || folder.querySelector('.child-folder-container');
+        if (!subfoldersContainer) return;
+
+        const subfolders = subfoldersContainer.querySelectorAll('.nav-folder') || subfoldersContainer.querySelectorAll('.child-folder');
+        if (!subfolders.length) return;
+
+        const collapsePromises = Array.from(subfolders).map(subfolder => this.collapseSubfolder(subfolder));
+        await Promise.all(collapsePromises);
     }
 
     collapseSubfolder(subfolder) {
-        return new Promise(async resolve => {
-            const observer = new MutationObserver(mutations => {
-                mutations.forEach(mutation => {
-                    if (mutation.target.classList.contains('is-collapsed')) {
-                        observer.disconnect();
-                        resolve();
+        return new Promise(async (resolve) => {
+            const observer = new MutationObserver((mutations) => {
+                for (const mutation of mutations) {
+                    if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                        if (mutation.target.classList.contains('is-collapsed')) {
+                            observer.disconnect();
+                            resolve();
+                        }
                     }
-                });
+                }
             });
 
             observer.observe(subfolder, { attributes: true, attributeFilter: ['class'] });
 
-            const collapseIcon = subfolder.querySelector('.nav-folder-collapse-indicator');
+            const collapseIcon = subfolder.querySelector('.collapse-icon') || subfolder.querySelector('[data-action="toggle-folder"]');
             if (collapseIcon && !subfolder.classList.contains('is-collapsed')) {
                 collapseIcon.click();
-                await sleep(100);
+                await sleep(200); // Accommodate potential animation delays
             } else {
+                observer.disconnect();
                 resolve();
             }
         });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "auto-folder-collapse",
     "name": "Auto Folder Collapse",
-    "version": "1.0.6",
+    "version": "1.1.0",
     "minAppVersion": "0.12.0",
     "description": "Automatically collapses subfolders when a parent folder is collapsed",
     "author": "Dario Casciato",


### PR DESCRIPTION
he new Obsidian Version v1.7.4 did not support the auto folder collapse plugin. the plugin was updated to now support the new version. It is also reverse compatible with older obsidian versions.